### PR TITLE
Removed all argument parsing for wrapped modules

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -1,10 +1,12 @@
 import os
+import re
+import sys
+
 import tkinter as tk
 import tkinter.ttk as ttk
 import modules.list_repository
 import modules.build_definition
-import re
-import time
+
 from threading import Thread
 
 class BuildFrameObject:
@@ -109,15 +111,9 @@ class BuildFrameObject:
 
                 # cut off the last comma
                 build_query = re.search('(.*)(, $)', build_query).group(1)
-
-                class BuildArguments:
-                    options = None
-                    def __init__(self, o):
-                        self.options=o
-                query = f'--definition_id {build_query} --max_schema_version 5.11.1 -o out.xml'
-                args = BuildArguments(o=query)
-
-                modules.build_definition.build_definition(args)
+                query = f'b --definition_id {build_query} --max_schema_version 5.11.1 -o out.xml'
+                sys.argv = query.split(' ')
+                modules.build_definition.build_definition()
 
                 text.insert(tk.END, '\n\nBuilding done. File: out.xml')
 

--- a/lrm.py
+++ b/lrm.py
@@ -13,72 +13,58 @@ Author: Denis Yablochkin <denis-yablochkin.ib@yandex.ru>
 Copyright: https://github.com/CISecurity/OVALRepo
 Copyright© 2010 United States Government. All Rights Reserved.
 """
-import argparse
 
-# import custom modules
-import modules.list_repository as list_repository
-import modules.clear_repository as clear_repository
-import modules.build_definition as build_definition
-import modules.decompose_definition as decompose_definition
-import modules.validate_definition as validate_definition
-import modules.timestamp_definition as timestamp_definition
+import sys
 
-def main():
-    """Main parser with subparsers"""
-    main_parser = argparse.ArgumentParser(description='Local OVAL Repository Managment tool.')
-    main_parser.add_argument('-e', '--environment', help='Default Script Environment (folder with scripts and repository folder).')
-    subparsers = main_parser.add_subparsers(title='Main options', help ='Choose one of this options. Help available for each one.')
+# import custom parser
+from modules.ArgumentsParser import ArgumentsParser
 
 
-    """Parser for Clear module"""
-    parser_clear = subparsers.add_parser('c', help='Clear script environment. Use it if some troubles with building occurs.')
-    parser_clear.add_argument('-d', '--decomposed', action='store_true' ,help='Also clear .decomposed folder')
-    parser_clear.set_defaults(func=clear_repository.clear_repository)
+def main(args):
+    ArgumentsParser.parse_arguments(args)
 
-
-    """ Parser for List module"""
-    parser_list = subparsers.add_parser('l', help='List entries in repository.')
-    parser_list.add_argument('-m', '--mode', choices='adtosv', default='d', help='Output mode: all, definitions, tests, objects, states or variables. Default: only definitions.')
-    parser_list.add_argument('-f', '--format', choices='flh', help='Format options: full paths, count files in every category, hide definitions name')
-    parser_list.set_defaults(func=list_repository.list_repository)
-
-
-    """ Parser for Build module"""
-    parser_build = subparsers.add_parser('b', help='Build OVAL definitions from repository.')
-    parser_build.add_argument('-o', '--options', default='-h', help='Options for build module. Use "" for options. Pass only \'b\' to see full help from original module.')
-    parser_build.set_defaults(func=build_definition.build_definition_cli)
-
-
-    """ Parser for Decomposition module"""
-    parser_decompose = subparsers.add_parser('d', help='Decompose OVAL definitions to repository. It will replace entries with equal IDs. Use LIST to check IDs. You may specify path to directory and all xmls inside will be decomposed.')
-    parser_decompose.add_argument('-r', '--remove_decomposed', action='store_true', help='Replaces decomposed files to .decomposed folder.')
-    parser_decompose.add_argument('-o', '--options', help='Options for build module. Use "" for options. Pass only \'b\' to see full help from original module.')
-    parser_decompose.set_defaults(func=decompose_definition.decompose_definition)
-
-
-    """ Parser for Validation module"""
-    parser_validate = subparsers.add_parser('v', help='Validate OVAL definition with schema.')
-    parser_validate.add_argument('xml', help='Path to OVAL definition')
-    parser_validate.add_argument('xsd', help='Path to schema FOLDER. Default: version 5.10.1.')
-    parser_validate.set_defaults(func=validate_definition.validate_definition)
-
-    """Parser for timestamp_definition module"""
-    #parser = argparse.ArgumentParser(description='This tool will authomatically check the oval_repository field in all definitions. If there is no such field - the tool will add it. New file will be saved in *original-name*-formatted.xml.')
-    parser_ts = subparsers.add_parser('t', help='Insert valid <oval_repository> tag with timestamp in OVAL definitions file.')
-    parser_ts.add_argument('path', help='Path to XML with definition')
-    parser_ts.add_argument('contributor', help='Name of the contributor')
-    parser_ts.add_argument('organization', help='Name of the contributor\'s organization')
-    parser_ts.set_defaults(func=timestamp_definition.timestamp_definition)
-
-    """Process the parsers and start the program"""
-    args = main_parser.parse_args()
-    try:
-        args.func(args)
-    except AttributeError:
-        main_parser.print_help()
-
+    #""" Parser for List module"""
+    #parser_list = subparsers.add_parser('l', help='List entries in repository.')
+    #parser_list.add_argument('-m', '--mode', choices='adtosv', default='d', help='Output mode: all, definitions, tests, objects, states or variables. Default: only definitions.')
+    #parser_list.add_argument('-f', '--format', choices='flh', help='Format options: full paths, count files in every category, hide definitions name')
+    #parser_list.set_defaults(func=list_repository.list_repository)
+    #
+    #
+    #""" Parser for Build module"""
+    #parser_build = subparsers.add_parser('b', help='Build OVAL definitions from repository.')
+    #parser_build.add_argument('-o', '--options', default='-h', help='Options for build module. Use "" for options. Pass only \'b\' to see full help from original module.')
+    #parser_build.set_defaults(func=build_definition.build_definition_cli)
+    #
+    #
+    #""" Parser for Decomposition module"""
+    #parser_decompose = subparsers.add_parser('d', help='Decompose OVAL definitions to repository. It will replace entries with equal IDs. Use LIST to check IDs. You may specify path to directory and all xmls inside will be decomposed.')
+    #parser_decompose.add_argument('-r', '--remove_decomposed', action='store_true', help='Replaces decomposed files to .decomposed folder.')
+    #parser_decompose.add_argument('-o', '--options', help='Options for build module. Use "" for options. Pass only \'b\' to see full help from original module.')
+    #parser_decompose.set_defaults(func=decompose_definition.decompose_definition)
+    #
+    #
+    #""" Parser for Validation module"""
+    #parser_validate = subparsers.add_parser('v', help='Validate OVAL definition with schema.')
+    #parser_validate.add_argument('xml', help='Path to OVAL definition')
+    #parser_validate.add_argument('xsd', help='Path to schema FOLDER. Default: version 5.10.1.')
+    #parser_validate.set_defaults(func=validate_definition.validate_definition)
+    #
+    #"""Parser for timestamp_definition module"""
+    ##parser = argparse.ArgumentParser(description='This tool will authomatically check the oval_repository field in all definitions. If there is no such field - the tool will add it. New file will be saved in *original-name*-formatted.xml.')
+    #parser_ts = subparsers.add_parser('t', help='Insert valid <oval_repository> tag with timestamp in OVAL definitions file.')
+    #parser_ts.add_argument('path', help='Path to XML with definition')
+    #parser_ts.add_argument('contributor', help='Name of the contributor')
+    #parser_ts.add_argument('organization', help='Name of the contributor\'s organization')
+    #parser_ts.set_defaults(func=timestamp_definition.timestamp_definition)
+    #
+    #"""Process the parsers and start the program"""
+    #args = main_parser.parse_args()
+    #try:
+    #    args.func(args)
+    #except AttributeError:
+    #    main_parser.print_help()
 
 
 # always need this to make sure that module was not called from return of submodules
 if __name__ == '__main__':
-    main()
+    main(sys.argv)

--- a/lrm.py
+++ b/lrm.py
@@ -13,58 +13,12 @@ Author: Denis Yablochkin <denis-yablochkin.ib@yandex.ru>
 Copyright: https://github.com/CISecurity/OVALRepo
 Copyright© 2010 United States Government. All Rights Reserved.
 """
-
-import sys
-
-# import custom parser
 from modules.ArgumentsParser import ArgumentsParser
 
 
-def main(args):
-    ArgumentsParser.parse_arguments(args)
-
-    #""" Parser for List module"""
-    #parser_list = subparsers.add_parser('l', help='List entries in repository.')
-    #parser_list.add_argument('-m', '--mode', choices='adtosv', default='d', help='Output mode: all, definitions, tests, objects, states or variables. Default: only definitions.')
-    #parser_list.add_argument('-f', '--format', choices='flh', help='Format options: full paths, count files in every category, hide definitions name')
-    #parser_list.set_defaults(func=list_repository.list_repository)
-    #
-    #
-    #""" Parser for Build module"""
-    #parser_build = subparsers.add_parser('b', help='Build OVAL definitions from repository.')
-    #parser_build.add_argument('-o', '--options', default='-h', help='Options for build module. Use "" for options. Pass only \'b\' to see full help from original module.')
-    #parser_build.set_defaults(func=build_definition.build_definition_cli)
-    #
-    #
-    #""" Parser for Decomposition module"""
-    #parser_decompose = subparsers.add_parser('d', help='Decompose OVAL definitions to repository. It will replace entries with equal IDs. Use LIST to check IDs. You may specify path to directory and all xmls inside will be decomposed.')
-    #parser_decompose.add_argument('-r', '--remove_decomposed', action='store_true', help='Replaces decomposed files to .decomposed folder.')
-    #parser_decompose.add_argument('-o', '--options', help='Options for build module. Use "" for options. Pass only \'b\' to see full help from original module.')
-    #parser_decompose.set_defaults(func=decompose_definition.decompose_definition)
-    #
-    #
-    #""" Parser for Validation module"""
-    #parser_validate = subparsers.add_parser('v', help='Validate OVAL definition with schema.')
-    #parser_validate.add_argument('xml', help='Path to OVAL definition')
-    #parser_validate.add_argument('xsd', help='Path to schema FOLDER. Default: version 5.10.1.')
-    #parser_validate.set_defaults(func=validate_definition.validate_definition)
-    #
-    #"""Parser for timestamp_definition module"""
-    ##parser = argparse.ArgumentParser(description='This tool will authomatically check the oval_repository field in all definitions. If there is no such field - the tool will add it. New file will be saved in *original-name*-formatted.xml.')
-    #parser_ts = subparsers.add_parser('t', help='Insert valid <oval_repository> tag with timestamp in OVAL definitions file.')
-    #parser_ts.add_argument('path', help='Path to XML with definition')
-    #parser_ts.add_argument('contributor', help='Name of the contributor')
-    #parser_ts.add_argument('organization', help='Name of the contributor\'s organization')
-    #parser_ts.set_defaults(func=timestamp_definition.timestamp_definition)
-    #
-    #"""Process the parsers and start the program"""
-    #args = main_parser.parse_args()
-    #try:
-    #    args.func(args)
-    #except AttributeError:
-    #    main_parser.print_help()
-
+def main():
+    ArgumentsParser.parse_arguments()
 
 # always need this to make sure that module was not called from return of submodules
 if __name__ == '__main__':
-    main(sys.argv)
+    main()

--- a/modules/ArgumentsParser.py
+++ b/modules/ArgumentsParser.py
@@ -1,13 +1,13 @@
-import re
 import argparse
+import sys
 
+import modules.build_definition as build_definition
+import modules.clear_repository as clear_repository
+import modules.decompose_definition as decompose_definition
 # custom modules
 import modules.list_repository as list_repository
-import modules.clear_repository as clear_repository
-import modules.build_definition as build_definition
-import modules.decompose_definition as decompose_definition
-import modules.validate_definition as validate_definition
 import modules.timestamp_definition as timestamp_definition
+import modules.validate_definition as validate_definition
 
 
 class ArgumentsParser:
@@ -18,18 +18,18 @@ class ArgumentsParser:
     loosing command-line autocomplete.
     """
 
-
-
     @staticmethod
-    def parse_arguments(args):
+    def parse_arguments():
 
         # Second argument is always a function name, so it will decide if i use argparse or custom parser.
         # There is no need to use argparse for wrapped modules - they have their own argparse.
         wrapped_modules = ['b', 'd']
         try:
-            if args[1] in wrapped_modules:
-                ArgumentsParser.__call_wrapped_modules(args)
+            if sys.argv[1] in wrapped_modules:
+                # call wrapped modules directly
+                ArgumentsParser.__call_wrapped_modules()
             else:
+                # call own parsers first
                 ArgumentsParser.__call_argparse()
         except IndexError as e:
             print(e)
@@ -37,17 +37,16 @@ class ArgumentsParser:
 
         pass
 
-
     @staticmethod
-    def __call_wrapped_modules(args):
+    def __call_wrapped_modules():
         """
         This method will be called if user DOES want to use some OVAL Repo modules. These modules already have
         argparse library inside, so we only want to run modules.
         """
-        if args[1] == 'b':
-            build_definition.build_definition_cli(args)
-        elif args[1] == 'd':
-            decompose_definition.decompose_definition(args)
+        if sys.argv[1] == 'b':
+            build_definition.build_definition_cli()
+        elif sys.argv[1] == 'd':
+            decompose_definition.decompose_definition()
         pass
 
     @staticmethod
@@ -58,10 +57,9 @@ class ArgumentsParser:
 
         """
 
-
         """Main parser with subparsers"""
         main_parser = argparse.ArgumentParser(description='Local OVAL Repository Managment tool.')
-        #main_parser.add_argument('-e', '--environment',
+        # main_parser.add_argument('-e', '--environment',
         #                         help='Default Script Environment (folder with scripts and repository folder).')
         subparsers = main_parser.add_subparsers(title='Main options',
                                                 help='Choose one of this options. Help available for each one.')
@@ -121,24 +119,6 @@ class ArgumentsParser:
         parser_ts.set_defaults(func=timestamp_definition.timestamp_definition)
         args = main_parser.parse_args()
         try:
-           args.func(args)
+            args.func(args)
         except AttributeError:
-           main_parser.print_help()
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+            main_parser.print_help()

--- a/modules/ArgumentsParser.py
+++ b/modules/ArgumentsParser.py
@@ -1,0 +1,144 @@
+import re
+import argparse
+
+# custom modules
+import modules.list_repository as list_repository
+import modules.clear_repository as clear_repository
+import modules.build_definition as build_definition
+import modules.decompose_definition as decompose_definition
+import modules.validate_definition as validate_definition
+import modules.timestamp_definition as timestamp_definition
+
+
+class ArgumentsParser:
+    """
+    Custom parser for arguments.
+    Internal modules such as build_definition have their own standard argument parsers so i've decided to
+    write my own. I do not see a good way to wrap other argument parsers without writing my own and
+    loosing command-line autocomplete.
+    """
+
+
+
+    @staticmethod
+    def parse_arguments(args):
+
+        # Second argument is always a function name, so it will decide if i use argparse or custom parser.
+        # There is no need to use argparse for wrapped modules - they have their own argparse.
+        wrapped_modules = ['b', 'd']
+        try:
+            if args[1] in wrapped_modules:
+                ArgumentsParser.__call_wrapped_modules(args)
+            else:
+                ArgumentsParser.__call_argparse()
+        except IndexError as e:
+            print(e)
+            ArgumentsParser.__call_argparse()
+
+        pass
+
+
+    @staticmethod
+    def __call_wrapped_modules(args):
+        """
+        This method will be called if user DOES want to use some OVAL Repo modules. These modules already have
+        argparse library inside, so we only want to run modules.
+        """
+        if args[1] == 'b':
+            build_definition.build_definition_cli(args)
+        elif args[1] == 'd':
+            decompose_definition.decompose_definition(args)
+        pass
+
+    @staticmethod
+    def __call_argparse():
+        """
+        This method will be called if user does not tries to use wrapper for decomposition or build.
+        We'll need our own argument parsers for this.
+
+        """
+
+
+        """Main parser with subparsers"""
+        main_parser = argparse.ArgumentParser(description='Local OVAL Repository Managment tool.')
+        #main_parser.add_argument('-e', '--environment',
+        #                         help='Default Script Environment (folder with scripts and repository folder).')
+        subparsers = main_parser.add_subparsers(title='Main options',
+                                                help='Choose one of this options. Help available for each one.')
+
+        """Parser for Clear module"""
+        parser_clear = subparsers.add_parser('c',
+                                             help='Clear script environment. Use it if some troubles with building '
+                                                  'occurs.')
+        parser_clear.add_argument('-d', '--decomposed', action='store_true', help='Also clear .decomposed folder')
+        parser_clear.set_defaults(func=clear_repository.clear_repository)
+
+        """ Parser for List module"""
+        parser_list = subparsers.add_parser('l', help='List entries in repository.')
+        parser_list.add_argument('-m', '--mode', choices='adtosv', default='d',
+                                 help='Output mode: all, definitions, tests, objects, states or variables. Default: '
+                                      'only definitions.')
+        parser_list.add_argument('-f', '--format', choices='flh',
+                                 help='Format options: full paths, count files in every category, hide definitions name')
+        parser_list.set_defaults(func=list_repository.list_repository)
+
+        """ Parser for Build module"""
+        parser_build = subparsers.add_parser('b', help='Build OVAL definitions from repository.')
+        parser_build.add_argument('-o', '--options', default='-h',
+                                  help='Options for build module. Use "" for options. Pass only \'b\' to see full '
+                                       'help from original module.')
+        parser_build.set_defaults(func=build_definition.build_definition_cli)
+
+        """ Parser for Decomposition module"""
+        parser_decompose = subparsers.add_parser('d',
+                                                 help='Decompose OVAL definitions to repository. It will replace '
+                                                      'entries with equal IDs. Use LIST to check IDs. You may specify '
+                                                      'path to directory and all xmls inside will be decomposed.')
+        parser_decompose.add_argument('-r', '--remove_decomposed', action='store_true',
+                                      help='Replaces decomposed files to .decomposed folder.')
+        parser_decompose.add_argument('-o', '--options',
+                                      help='Options for build module. Use "" for options. Pass only \'b\' to see full '
+                                           'help from original module.')
+        parser_decompose.set_defaults(func=decompose_definition.decompose_definition)
+
+        """ Parser for Validation module"""
+        parser_validate = subparsers.add_parser('v', help='Validate OVAL definition with schema.')
+        parser_validate.add_argument('xml', help='Path to OVAL definition')
+        parser_validate.add_argument('xsd', help='Path to schema FOLDER. Default: version 5.10.1.')
+        parser_validate.set_defaults(func=validate_definition.validate_definition)
+
+        """Parser for timestamp_definition module"""
+        parser = argparse.ArgumentParser(description='This tool will automatically check the oval_repository field '
+                                                     'in all definitions. If there is no such field - the tool will '
+                                                     'add it. New file will be saved in '
+                                                     '*original-name*-formatted.xml.')
+        parser_ts = subparsers.add_parser('t',
+                                          help='Insert valid <oval_repository> tag with timestamp in OVAL definitions '
+                                               'file.')
+        parser_ts.add_argument('path', help='Path to XML with definition')
+        parser_ts.add_argument('contributor', help='Name of the contributor')
+        parser_ts.add_argument('organization', help='Name of the contributor\'s organization')
+        parser_ts.set_defaults(func=timestamp_definition.timestamp_definition)
+        args = main_parser.parse_args()
+        try:
+           args.func(args)
+        except AttributeError:
+           main_parser.print_help()
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/modules/build_definition.py
+++ b/modules/build_definition.py
@@ -29,6 +29,7 @@ def build_definition(args):
     growth when indexing OVAL repository with git all the time. It is faster
     to just commit one little file and make build.
     """
+
     for a in vars(args)['options'].split(' '):
         sys.argv.append(a)
   

--- a/modules/build_definition.py
+++ b/modules/build_definition.py
@@ -1,55 +1,50 @@
-import os, shutil, sys, random
+import os
+import shutil
+import sys
+
 from git import Repo
 from git.exc import InvalidGitRepositoryError
 
 sys.path.insert(1, os.path.relpath('./ScriptsEnvironment/scripts'))
 import ScriptsEnvironment.scripts.build_oval_definitions_file as build_oval_definitions_file
 
-def build_definition_cli(args):
+
+def build_definition_cli():
     """
-    Removing 1, 2 and 3 arguments of command line because
-    build_oval_definitions_file will process command line arguments
-    with own parser. In GUI we won't need this since we'll operate with
-    build_definition directly and do not use arguments.
+    Removing 1  argument of command line because build_oval_definitions_file
+    will process command line arguments with own parser (but it want optional
+    arguments to start from index '1').
+
+    In GUI we won't need this since we'll operate with build_definition directly and do not use arguments.
     """
-
-    if len(sys.argv)>2:
-        try:
-            for i in range(0,3):
-                sys.argv.pop(1)
-        except IndexError:
-            pass
-    build_definition(args)
+    sys.argv.pop(0)
+    build_definition()
 
 
-
-def build_definition(args):
+def build_definition():
     """
     This function will create fake GIT environment. There is no visible speed
     growth when indexing OVAL repository with git all the time. It is faster
-    to just commit one little file and make build.
+    to just commit one little file and start build the definition.
     """
 
-    for a in vars(args)['options'].split(' '):
-        sys.argv.append(a)
-  
     # creating fake environment for scripts
     try:
         shutil.rmtree(os.path.relpath('./ScriptsEnvironment/.git'))
         os.remove(os.path.relpath('./ScriptsEnvironment/.init'))
-    except:
+    except FileNotFoundError:
         pass
 
     with open(os.path.relpath('./ScriptsEnvironment/.init'), 'w') as file:
         file.write('init')
-        
+
     try:
         repo = Repo(os.path.relpath('./ScriptsEnvironment'))
     except InvalidGitRepositoryError:
         repo = Repo.init(os.path.relpath('./ScriptsEnvironment'))
-    
+
     index = repo.index
-    index.add( [ '.init' ] )
+    index.add(['.init'])
     index.commit("env")
 
     build_oval_definitions_file.main()
@@ -58,5 +53,5 @@ def build_definition(args):
     try:
         shutil.rmtree(os.path.relpath('./ScriptsEnvironment/.git'))
         os.remove(os.path.relpath('./ScriptsEnvironment/.init'))
-    except:
+    except FileNotFoundError:
         pass

--- a/modules/decompose_definition.py
+++ b/modules/decompose_definition.py
@@ -1,42 +1,47 @@
-import os, sys, shutil, re, time
-from datetime import datetime
+import os, sys, shutil, re, time, datetime
 sys.path.insert(1, os.path.relpath('./ScriptsEnvironment/scripts'))
 import ScriptsEnvironment.scripts.oval_decomposition as oval_decomposition
 
-def decompose_definition(args):
+
+def decompose_definition():
     # removing 1 and 2 arguments of command line because
     # oval_decomposition will use them with own parser
     sys.argv.pop(0)
     sys.argv.pop(0)
 
-    # check if there is auto_remove_decomposed flag
-    #if ''
-
-    # check if input path is a folder
+    # getting input path to a variable to check if it is a folder later
     input_path = None
     try:
-        input_path = re.search(r'-f (?P<input_path>(\S*))', ' '.join(args))['input_path']
+        input_path = re.search(r'-f (?P<input_path>(\S*))', ' '.join(sys.argv))['input_path']
     except TypeError as e:
         sys.argv.clear()
         sys.argv.append('-h')
+
+    if '-h' in sys.argv:
+        print_own_help()
         oval_decomposition.main()
+        return
 
-    #auto_remove_decomposed = vars(args)['remove_decomposed']
+    remove_decomposed = False
+    if '-r' in sys.argv:
+        remove_index = sys.argv.index('-r')
+        sys.argv.pop(remove_index)
+        remove_decomposed = True
 
-    configs = [ ]    
+    configs = []
+    # if this is a dir - take all files for decomposing
     if os.path.isdir(input_path):
         configs_root = os.path.relpath(input_path)
-        file_list=os.listdir(os.path.relpath(input_path))
+        file_list = os.listdir(os.path.relpath(input_path))
         for file in file_list:
-            configs.append(configs_root+os.sep+file)
+            configs.append(configs_root + os.sep + file)
     else:
         configs.append(os.path.relpath(input_path))
 
-
     for config in configs:
-        sys.stdout.write("Decomposing "+config+" ...")
+        sys.stdout.write("Decomposing " + config + " ...")
         sys.stdout.flush()
-        
+
         # new console arguments for every config because
         # oval_decomposition uses it's own argument parser
         is_verbose = False
@@ -52,20 +57,30 @@ def decompose_definition(args):
             time.sleep(1)
         oval_decomposition.main()
 
-
         # replaces decomposed configs in .decomposed folder
-        #if auto_remove_decomposed:
-        #    config_name=config.split(os.sep)[len(config.split(os.sep))-1]
-        #    path = os.path.abspath(sys.argv[2])
-        #    try:
-        #        os.mkdir(os.path.abspath('./.decomposed'))
-        #        os.system("attrib +h " + os.path.abspath('./.decomposed'))
-        #    except:
-        #        pass
-        #    time=datetime.now()
-        #    ts=str(datetime.timestamp(time))
-        #    shutil.move(path,os.path.abspath('./.decomposed/'+ts+' '+config_name))
+        if remove_decomposed:
+            # last word after / is a name of file
+            config_name = config.split(os.sep)[len(config.split(os.sep)) - 1]
+            path = os.path.abspath(sys.argv[2])
+            try:
+                os.mkdir(os.path.abspath('./.decomposed'))
+                os.system("attrib +h " + os.path.abspath('./.decomposed'))
+            except FileExistsError:
+                pass
+
+            # timestamp for no replacing decomposed files with same names
+            now = datetime.datetime.now()
+            ts = str(datetime.datetime.timestamp(now))
+            shutil.move(path, os.path.abspath('./.decomposed/' + ts + ' ' + config_name))
 
         sys.stdout.write(" Success\n")
         sys.stdout.flush()
 
+
+def print_own_help():
+    help_message = '''Additional info for decompose: 
+    -f may also include a folder (no spaces in name allowed). All definitions in folder will be decomposed
+    -v verbose output (print all created/replaced files)
+    -r remove decomposed files to .decompose folder
+    '''
+    print(help_message)

--- a/modules/decompose_definition.py
+++ b/modules/decompose_definition.py
@@ -1,27 +1,27 @@
-import os, sys, shutil, re
+import os, sys, shutil, re, time
 from datetime import datetime
 sys.path.insert(1, os.path.relpath('./ScriptsEnvironment/scripts'))
 import ScriptsEnvironment.scripts.oval_decomposition as oval_decomposition
 
-def decompose_definition( args ):
-    # removing 1, 2 and 3 arguments of command line because
+def decompose_definition(args):
+    # removing 1 and 2 arguments of command line because
     # oval_decomposition will use them with own parser
-    verbose_output = False
-    input_path=''
-    # take path from arguments: -f <path> and check for -v flag
+    sys.argv.pop(0)
+    sys.argv.pop(0)
+
+    # check if there is auto_remove_decomposed flag
+    #if ''
+
+    # check if input path is a folder
+    input_path = None
     try:
-        if re.search('(^-v)|(-v$)', vars(args)['options'].strip()):
-            verbose_output=True
-        input_path = vars(args)['options'].split('-f ')[1]
-        input_path = input_path.split(' ')[0]
-    except Exception:
-        # call help from oval_decomposition if no path specified
+        input_path = re.search(r'-f (?P<input_path>(\S*))', ' '.join(args))['input_path']
+    except TypeError as e:
         sys.argv.clear()
-        sys.argv.append('')
         sys.argv.append('-h')
         oval_decomposition.main()
 
-    auto_remove_decomposed = vars(args)['remove_decomposed']
+    #auto_remove_decomposed = vars(args)['remove_decomposed']
 
     configs = [ ]    
     if os.path.isdir(input_path):
@@ -39,26 +39,33 @@ def decompose_definition( args ):
         
         # new console arguments for every config because
         # oval_decomposition uses it's own argument parser
+        is_verbose = False
+        if '-v' in sys.argv:
+            is_verbose = True
         sys.argv.clear()
         sys.argv.append('')
         sys.argv.append('-f')
         sys.argv.append(config)
-        if verbose_output:
+        if is_verbose:
             sys.argv.append('-v')
+            # This is because you want to see when it switches to another file on decomposing
+            time.sleep(1)
         oval_decomposition.main()
 
+
         # replaces decomposed configs in .decomposed folder
-        if auto_remove_decomposed:
-            config_name=config.split(os.sep)[len(config.split(os.sep))-1]
-            path = os.path.abspath(sys.argv[2])
-            try:
-                os.mkdir(os.path.abspath('./.decomposed'))
-                os.system("attrib +h " + os.path.abspath('./.decomposed'))
-            except:
-                pass
-            time=datetime.now()
-            ts=str(datetime.timestamp(time))
-            shutil.move(path,os.path.abspath('./.decomposed/'+ts+' '+config_name))
+        #if auto_remove_decomposed:
+        #    config_name=config.split(os.sep)[len(config.split(os.sep))-1]
+        #    path = os.path.abspath(sys.argv[2])
+        #    try:
+        #        os.mkdir(os.path.abspath('./.decomposed'))
+        #        os.system("attrib +h " + os.path.abspath('./.decomposed'))
+        #    except:
+        #        pass
+        #    time=datetime.now()
+        #    ts=str(datetime.timestamp(time))
+        #    shutil.move(path,os.path.abspath('./.decomposed/'+ts+' '+config_name))
 
         sys.stdout.write(" Success\n")
         sys.stdout.flush()
+


### PR DESCRIPTION
Now there is no argument --o "options for wrapped modules" so autocomplete from CLI will work. Now modules may be called like this:
```
python lrm.py b --definition_id test:1 --max_schema_version 5.11.1 -o out.xml"
python lrm.py d -f test.xml -v
```